### PR TITLE
fix: add supabase to bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "replicache-nextjs",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Generic Replicache backend on Next.js",
   "homepage": "https://github.com/rocicorp/replicache-nextjs",
   "repository": "github:rocicorp/replicache-nextjs",
@@ -19,7 +19,8 @@
     "react": ">=16.0 <18.0",
     "react-dom": ">=16.0 <18.0",
     "replicache": ">=11.0.0",
-    "pg-mem": ">=2.5.0"
+    "pg-mem": ">=2.5.0",
+    "@supabase/supabase-js": ">=1.35.3"
   },
   "devDependencies": {
     "@rocicorp/logger": "^2.2.0",


### PR DESCRIPTION
When removing supabase as a dependency on the todo app, the build broke because it wasn't bundling in the nextjs package.