### PR TITLE
remove unnecessary useReplicache check for falsey spaceID & fix types

### DIFF
--- a/src/frontend/use-replicache.ts
+++ b/src/frontend/use-replicache.ts
@@ -3,7 +3,7 @@ import { MutatorDefs, Replicache } from "replicache";
 import { getPokeReceiver } from "./poke.js";
 
 export function useReplicache<M extends MutatorDefs>(
-  spaceID: string,
+  spaceID: string | null | undefined,
   mutators: M
 ) {
   const [rep, setRep] = useState<Replicache<M> | null>(null);

--- a/src/frontend/use-replicache.ts
+++ b/src/frontend/use-replicache.ts
@@ -45,7 +45,7 @@ export function useReplicache<M extends MutatorDefs>(
     })().catch((e) => console.error(e));
   }, [spaceID, mutators]);
 
-  if (!spaceID || !rep) {
+  if (!rep) {
     return null;
   }
 


### PR DESCRIPTION
We never set rep if spaceID is falsey and rep is null by default. We also need to allow spaceID to be null/undefined. Original PR: https://github.com/rocicorp/replicache-nextjs/pull/6