### PR TITLE
chore: Add an engine dependency on npm 7.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,10 @@
         "ts-node": "^10.7.0",
         "typescript": "^4.7.4"
       },
+      "engines": {
+        "//": "npm 7 not strictly *required* but without, you need to manually install the peerDependencies below",
+        "npm": ">=7.0.0"
+      },
       "peerDependencies": {
         "@supabase/supabase-js": ">=1.35.3",
         "next": ">=12.1.6",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "pretest": "npm run build",
     "test": "mocha --ui=tdd 'lib/**/*.test.js'"
   },
+  "engines": {
+    "//": "npm 7 not strictly *required* but without, you need to manually install the peerDependencies below",
+    "npm": ">=7.0.0"
+  },
   "peerDependencies": {
     "@supabase/supabase-js": ">=1.35.3",
     "next": ">=12.1.6",


### PR DESCRIPTION
peerDependencies autoinstall since npm 7 and dependent sample apps rely on this behavior.

This engine requirement helps detect/warn about a situation where a user has an old npm version and dependent apps don't install correctly as a result.